### PR TITLE
feat(mock) add a mock for search repo and move it to the binary interface EE-1599

### DIFF
--- a/binary/search_repo.go
+++ b/binary/search_repo.go
@@ -1,4 +1,4 @@
-package libhelm
+package binary
 
 // Package common implements common functionality for the helm.
 // The functionality does not rely on the implementation of `HelmPackageManager`
@@ -45,7 +45,7 @@ type Entry struct {
 // SearchRepo downloads the `index.yaml` file for specified repo, parses it and returns JSON to caller.
 // The functionality is similar to that of what `helm search repo [chart] --repo <repo>` CLI runs;
 // this approach is used instead since the `helm search repo` requires a repo to be added to the global helm cache
-func SearchRepo(searchRepoOpts options.SearchRepoOptions) ([]byte, error) {
+func (hbpm *helmBinaryPackageManager) SearchRepo(searchRepoOpts options.SearchRepoOptions) ([]byte, error) {
 	if searchRepoOpts.Repo == "" {
 		return nil, errRequiredSearchOptions
 	}

--- a/binary/search_repo_test.go
+++ b/binary/search_repo_test.go
@@ -1,4 +1,4 @@
-package libhelm
+package binary
 
 import (
 	"testing"
@@ -11,6 +11,8 @@ import (
 func Test_SearchRepo(t *testing.T) {
 	libhelmtest.EnsureIntegrationTest(t)
 	is := assert.New(t)
+
+	hpm := NewHelmBinaryPackageManager("")
 
 	type testCase struct {
 		name    string
@@ -30,7 +32,7 @@ func Test_SearchRepo(t *testing.T) {
 		func(tc testCase) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
-				response, err := SearchRepo(options.SearchRepoOptions{tc.url})
+				response, err := hpm.SearchRepo(options.SearchRepoOptions{tc.url})
 				if tc.invalid {
 					is.Errorf(err, "error expected: %s", tc.url)
 				} else {

--- a/binary/test/mock.go
+++ b/binary/test/mock.go
@@ -1,9 +1,14 @@
 package test
 
 import (
+	"encoding/json"
+	"strings"
+
+	"github.com/pkg/errors"
 	"github.com/portainer/libhelm"
 	"github.com/portainer/libhelm/options"
 	"github.com/portainer/libhelm/release"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -86,4 +91,45 @@ func (hpm *helmMockPackageManager) Uninstall(uninstallOpts options.UninstallOpti
 // List a helm chart (not thread safe)
 func (hpm *helmMockPackageManager) List(listOpts options.ListOptions) ([]release.ReleaseElement, error) {
 	return mockCharts, nil
+}
+
+const mockPortainerIndex = `apiVersion: v1
+entries:
+  portainer:
+  - apiVersion: v2
+    appVersion: 2.0.0
+    created: "2020-12-01T21:51:37.367634957Z"
+    description: Helm chart used to deploy the Portainer for Kubernetes
+    digest: f0e13dd3e7a05d17cb35c7879ffa623fd43b2c10ca968203e302b7a6c2764ddb
+    home: https://www.portainer.io
+    icon: https://github.com/portainer/portainer/raw/develop/app/assets/ico/apple-touch-icon.png
+    maintainers:
+    - email: davidy@funkypenguin.co.nz
+      name: funkypenguin
+      url: https://www.funkypenguin.co.nz
+    name: portainer
+    sources:
+    - https://github.com/portainer/k8s
+    type: application
+    urls:
+    - https://github.com/portainer/k8s/releases/download/portainer-1.0.6/portainer-1.0.6.tgz
+    version: 1.0.6
+generated: "2020-08-19T00:00:46.754739363Z"`
+
+func (hbpm *helmMockPackageManager) SearchRepo(searchRepoOpts options.SearchRepoOptions) ([]byte, error) {
+	// Always return the same repo data no matter what
+	reader := strings.NewReader(mockPortainerIndex)
+
+	var file release.File
+	err := yaml.NewDecoder(reader).Decode(&file)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to decode index file")
+	}
+
+	result, err := json.Marshal(file)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal index file")
+	}
+
+	return result, nil
 }

--- a/helm.go
+++ b/helm.go
@@ -8,6 +8,7 @@ import (
 // HelmPackageManager represents a service that interfaces with Helm
 type HelmPackageManager interface {
 	Show(showOpts options.ShowOptions) ([]byte, error)
+	SearchRepo(searchRepoOpts options.SearchRepoOptions) ([]byte, error)
 	List(listOpts options.ListOptions) ([]release.ReleaseElement, error)
 	Install(installOpts options.InstallOptions) (*release.Release, error)
 	Uninstall(uninstallOpts options.UninstallOptions) error


### PR DESCRIPTION
Allow searchRepo to be mocked by moving it back into to the HelmPackageManager interface and the binary.

Closes [EE-1599](https://portainer.atlassian.net/browse/EE-1599)