### PR TITLE
feat(helm): helm apps deployed by portainer not marked as external EE-1624

### DIFF
--- a/binary/get.go
+++ b/binary/get.go
@@ -1,0 +1,29 @@
+package binary
+
+import (
+	"github.com/pkg/errors"
+	"github.com/portainer/libhelm/options"
+)
+
+// Get runs `helm get` with specified get options.
+// The get options translate to CLI arguments which are passed in to the helm binary when executing install.
+func (hbpm *helmBinaryPackageManager) Get(getOpts options.GetOptions) ([]byte, error) {
+	if getOpts.Name == "" || getOpts.ReleaseResource == "" {
+		return nil, errors.New("release name and release resource are required")
+	}
+
+	args := []string{
+		string(getOpts.ReleaseResource),
+		getOpts.Name,
+	}
+	if getOpts.Namespace != "" {
+		args = append(args, "--namespace", getOpts.Namespace)
+	}
+
+	result, err := hbpm.runWithKubeConfig("get", args, getOpts.KubernetesClusterAccess)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to run helm get on specified args")
+	}
+
+	return result, nil
+}

--- a/binary/install.go
+++ b/binary/install.go
@@ -29,6 +29,9 @@ func (hbpm *helmBinaryPackageManager) Install(installOpts options.InstallOptions
 	if installOpts.Wait {
 		args = append(args, "--wait")
 	}
+	if installOpts.PostRenderer != "" {
+		args = append(args, "--post-renderer", installOpts.PostRenderer)
+	}
 
 	result, err := hbpm.runWithKubeConfig("install", args, installOpts.KubernetesClusterAccess)
 	if err != nil {

--- a/binary/install.go
+++ b/binary/install.go
@@ -26,6 +26,9 @@ func (hbpm *helmBinaryPackageManager) Install(installOpts options.InstallOptions
 	if installOpts.ValuesFile != "" {
 		args = append(args, "--values", installOpts.ValuesFile)
 	}
+	if installOpts.Wait {
+		args = append(args, "--wait")
+	}
 
 	result, err := hbpm.runWithKubeConfig("install", args, installOpts.KubernetesClusterAccess)
 	if err != nil {

--- a/binary/search_repo_test.go
+++ b/binary/search_repo_test.go
@@ -32,7 +32,7 @@ func Test_SearchRepo(t *testing.T) {
 		func(tc testCase) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
-				response, err := hpm.SearchRepo(options.SearchRepoOptions{tc.url})
+				response, err := hpm.SearchRepo(options.SearchRepoOptions{Repo: tc.url})
 				if tc.invalid {
 					is.Errorf(err, "error expected: %s", tc.url)
 				} else {

--- a/binary/test/mock.go
+++ b/binary/test/mock.go
@@ -18,6 +18,13 @@ const (
 	MockDataValues = "mock-values"
 )
 
+const (
+	MockReleaseHooks    = "mock-release-hooks"
+	MockReleaseManifest = "mock-release-manifest"
+	MockReleaseNotes    = "mock-release-notes"
+	MockReleaseValues   = "mock-release-values"
+)
+
 // helmMockPackageManager is a test package for helm related http handler testing
 // Note: this package currently uses a slice in a way that is not thread safe.
 // Do not use this package for concurrent tests.
@@ -76,6 +83,24 @@ func (hpm *helmMockPackageManager) Show(showOpts options.ShowOptions) ([]byte, e
 		return []byte(MockDataValues), nil
 	}
 	return nil, nil
+}
+
+// Get release details - all, hooks, manifest, notes and values
+func (hpm *helmMockPackageManager) Get(getOpts options.GetOptions) ([]byte, error) {
+	switch getOpts.ReleaseResource {
+	case options.GetAll:
+		return []byte(strings.Join([]string{MockReleaseHooks, MockReleaseManifest, MockReleaseNotes, MockReleaseValues}, "---\n")), nil
+	case options.GetHooks:
+		return []byte(MockReleaseHooks), nil
+	case options.GetManifest:
+		return []byte(MockReleaseManifest), nil
+	case options.GetNotes:
+		return []byte(MockReleaseNotes), nil
+	case options.GetValues:
+		return []byte(MockReleaseValues), nil
+	default:
+		return nil, errors.New("invalid release resource")
+	}
 }
 
 // Uninstall a helm chart (not thread safe)

--- a/helm.go
+++ b/helm.go
@@ -9,6 +9,7 @@ import (
 type HelmPackageManager interface {
 	Show(showOpts options.ShowOptions) ([]byte, error)
 	SearchRepo(searchRepoOpts options.SearchRepoOptions) ([]byte, error)
+	Get(getOpts options.GetOptions) ([]byte, error)
 	List(listOpts options.ListOptions) ([]release.ReleaseElement, error)
 	Install(installOpts options.InstallOptions) (*release.Release, error)
 	Uninstall(uninstallOpts options.UninstallOptions) error

--- a/options/get_options.go
+++ b/options/get_options.go
@@ -1,0 +1,20 @@
+package options
+
+// releaseResource are the supported `helm get` sub-commands
+// to see all available sub-commands run `helm get --help`
+type releaseResource string
+
+const (
+	GetAll      releaseResource = "all"
+	GetHooks    releaseResource = "hooks"
+	GetManifest releaseResource = "manifest"
+	GetNotes    releaseResource = "notes"
+	GetValues   releaseResource = "values"
+)
+
+type GetOptions struct {
+	Name                    string
+	Namespace               string
+	ReleaseResource         releaseResource
+	KubernetesClusterAccess *KubernetesClusterAccess
+}

--- a/options/install_options.go
+++ b/options/install_options.go
@@ -5,6 +5,7 @@ type InstallOptions struct {
 	Chart                   string
 	Namespace               string
 	Repo                    string
+	Wait                    bool
 	ValuesFile              string
 	KubernetesClusterAccess *KubernetesClusterAccess
 }

--- a/options/install_options.go
+++ b/options/install_options.go
@@ -7,5 +7,6 @@ type InstallOptions struct {
 	Repo                    string
 	Wait                    bool
 	ValuesFile              string
+	PostRenderer            string
 	KubernetesClusterAccess *KubernetesClusterAccess
 }


### PR DESCRIPTION
Closes [EE-1624](https://portainer.atlassian.net/browse/EE-1624).

## Introduced Lib Features
- support for `helm get` (`all`, `values`, `notes`, `manifest`, `hooks`)
- support for `post-renderer` as install option
- support for `wait` as install option